### PR TITLE
Get dynamicLibraries via Embind

### DIFF
--- a/libvips/iofuncs/init-emscripten.cpp
+++ b/libvips/iofuncs/init-emscripten.cpp
@@ -1,0 +1,12 @@
+#include <emscripten/bind.h>
+
+extern "C" char **_emscripten_get_dynamic_libraries_js() {
+	auto dynamic_libraries = emscripten::val::module_property("dynamicLibraries");
+	int length = dynamic_libraries["length"].as<int>();
+	char **result = new char *[length + 1];
+	for (int i = 0; i < length; i++) {
+		result[i] = strdup(dynamic_libraries[i].as<std::string>().c_str());
+	}
+	result[length] = NULL;
+	return result;
+}

--- a/libvips/iofuncs/meson.build
+++ b/libvips/iofuncs/meson.build
@@ -37,6 +37,12 @@ iofuncs_sources = files(
     'buffer.c',
 )
 
+if host_os == 'emscripten'
+    iofuncs_sources += files(
+        'init-emscripten.cpp',
+    )
+endif
+
 iofuncs_headers = files(
     'sink.h',
 )


### PR DESCRIPTION
This allows to get rid of yet another custom Emscripten patch. It's tiny bit less efficient, but given that it's in a cold path and only executed for couple of strings, it doesn't matter for performance, but does simplify maintenance a bit by implementing the function locally at the libvips level.